### PR TITLE
Option<> for activate and deactivate fields in LV2Descriptor

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -30,9 +30,9 @@ pub struct LV2Descriptor {
                                    features: *const (*const LV2Feature))
                                    -> LV2Handle,
     pub connect_port: extern "C" fn(handle: LV2Handle, port: u32, data: *mut libc::c_void),
-    pub activate: extern "C" fn(instance: LV2Handle),
+    pub activate: Option<extern "C" fn(instance: LV2Handle)>,
     pub run: extern "C" fn(instance: LV2Handle, n_samples: u32),
-    pub deactivate: extern "C" fn(instance: LV2Handle),
+    pub deactivate: Option<extern "C" fn(instance: LV2Handle)>,
     pub cleanup: extern "C" fn(instance: LV2Handle),
     pub extension_data: extern "C" fn(uri: *const u8) -> (*const libc::c_void),
 }


### PR DESCRIPTION
LV2 spec allows NULL pointers for activate and deactivate fields in LV2Descriptor, so here they're Option'ed.

Using them in hosts will require additional checking, e.g.
```rust
if let Some(activate) = descriptor.activate {
    activate(handle);
}
```